### PR TITLE
feat: add option to expose custom port from MPS

### DIFF
--- a/helm/debug.sh
+++ b/helm/debug.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")"
+
+# See https://helm.sh/docs/chart_template_guide/debugging/
+helm install dev ./modelix -f dev.yaml --dry-run --debug

--- a/helm/modelix/templates/common/workspace-client-deployment.yaml
+++ b/helm/modelix/templates/common/workspace-client-deployment.yaml
@@ -50,6 +50,10 @@ spec:
           containerPort: 33334
         - name: "generator"
           containerPort: 33335
+        {{- range $index, $port := .Values.workspaces.client.customExposedPorts }}
+        - name: "custom-port-{{ $index }}"
+          containerPort: {{ $port }}
+        {{- end }}
         resources:
           requests:
             memory: "4.0Gi" # is replaced with the value in the workspace configuration

--- a/helm/modelix/templates/common/workspace-client-service.yaml
+++ b/helm/modelix/templates/common/workspace-client-service.yaml
@@ -24,6 +24,11 @@ spec:
   - name: "yourkit"
     port: 10001
     targetPort: "yourkit"
+  {{- range $index, $port := .Values.workspaces.client.customExposedPorts }}
+  - name: "custom-port-{{ $index }}"
+    port: {{ $port }}
+    targetPort: "custom-port-{{ $index }}"
+  {{- end }}
   selector:
     component: workspace-client
     {{- include "modelix.selectorLabels" . | nindent 4 }}

--- a/helm/modelix/templates/common/workspace-client-service.yaml
+++ b/helm/modelix/templates/common/workspace-client-service.yaml
@@ -11,19 +11,19 @@ spec:
   ports:
   - name: "projector"
     port: 8887
-    targetPort: 8887
+    targetPort: "projector"
   - name: "diff"
     port: 33334
-    targetPort: 33334
+    targetPort: "diff"
   - name: "generator"
     port: 33335
-    targetPort: 33335
-  - name: "debug"
+    targetPort: "generator"
+  - name: "jvmdebug"
     port: 5071
-    targetPort: 5071
+    targetPort: "jvmdebug"
   - name: "yourkit"
     port: 10001
-    targetPort: 10001
+    targetPort: "yourkit"
   selector:
     component: workspace-client
     {{- include "modelix.selectorLabels" . | nindent 4 }}

--- a/helm/modelix/templates/common/workspace-client-service.yaml
+++ b/helm/modelix/templates/common/workspace-client-service.yaml
@@ -12,9 +12,6 @@ spec:
   - name: "projector"
     port: 8887
     targetPort: 8887
-  - name: "modelix-ui"
-    port: 33333
-    targetPort: 33333
   - name: "diff"
     port: 33334
     targetPort: 33334

--- a/helm/modelix/values.yaml
+++ b/helm/modelix/values.yaml
@@ -22,7 +22,7 @@ imageTags:
 modelStorageSize: 3000Mi
 
 # Maximal size of request body in mebibyte for ingress and proxy.
-# Especially relevant for uploads in the workspace manger.
+# Especially relevant for uploads in the workspace manager.
 maxBodySize: 200
 
 developmentMode: false
@@ -40,6 +40,11 @@ workspaces:
   uploadsStorageSize: 5000Mi
   manager:
     memory: 600Mi
+  client:
+    # Ports as numbers which should be exposed from MPS.
+    #
+    # A use case is exposing custom servers running inside MPS.
+    customExposedPorts: []
 
 ingress:
   installController: true


### PR DESCRIPTION
Redirection to that port from the instance-manger is implemented in https://github.com/modelix/modelix.workspaces/pull/41