### PR TITLE
ci: use java 21 for the publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
The git-version requires it.